### PR TITLE
fix: adding_coma_after_rated_in_release

### DIFF
--- a/src/B2_build_movie_db.sql
+++ b/src/B2_build_movie_db.sql
@@ -112,7 +112,7 @@ CREATE TABLE release (
     release_id      INTEGER     PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     title           TEXT        NOT NULL,
     release_date    DATE        NULL,
-    rated           VARCHAR(80) NULL
+    rated           VARCHAR(80) NULL,
     "type"          VARCHAR(64) NULL,
     country_id      INTEGER     NULL REFERENCES country(country_id),
     media_id        INTEGER     NOT NULL REFERENCES media(media_id) 


### PR DESCRIPTION
Just added a coma to the code, because it was missing.