### PR TITLE
feat: structure_string_search function

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Portfolio Subproject made for the CIT 2024 course
 - Title
 	- *The title in that specific language.*
 
-- Type
+- Title Type
 	- *The different types of release, e.g., DVD, premiere.*
 
 ### Score

--- a/src/B2_build_movie_db.sql
+++ b/src/B2_build_movie_db.sql
@@ -113,7 +113,7 @@ CREATE TABLE release (
     title           TEXT        NOT NULL,
     release_date    DATE        NULL,
     rated           VARCHAR(80) NULL,
-    "type"          VARCHAR(64) NULL,
+    title_type      VARCHAR(64) NULL,
     country_id      INTEGER     NULL REFERENCES country(country_id),
     media_id        INTEGER     NOT NULL REFERENCES media(media_id) 
 );

--- a/src/D_functions_and_procedures.sql
+++ b/src/D_functions_and_procedures.sql
@@ -26,19 +26,19 @@ SELECT * FROM simple_search('apple',1);
 -- Structured string search
 
 CREATE OR REPLACE FUNCTION structured_string_search (
-  title VARCHAR(100), 
-  plot VARCHAR(100), 
-  "character" VARCHAR(100), 
-  person VARCHAR(100), 
-  user_id INTEGER
+  p_title VARCHAR(100), 
+  p_plot VARCHAR(100), 
+  p_character VARCHAR(100), 
+  p_person VARCHAR(100), 
+  p_user_id INTEGER
 )
 RETURNS TABLE (media_id INTEGER, title TEXT)
 AS $$
 BEGIN
   -- SEARCH HISTORY
-  INSERT INTO search_history (user_id, type, query)
+  INSERT INTO search_history (p_user_id, type, query)
   VALUES (user_id, 'structured_string_search', 
-          FORMAT('title: %s, plot: %s, character: %s, person: %s', title, plot, "character", person));
+          FORMAT('title: %s, plot: %s, character: %s, person: %s', p_title, p_plot, p_character, p_person));
 
   -- RESULT
   RETURN QUERY
@@ -50,10 +50,10 @@ BEGIN
         LEFT JOIN crew_member cr ON m.media_id = cr.media_id
         LEFT JOIN cast_member ca ON m.media_id = ca.media_id
         LEFT JOIN person p ON ca.person_id = p.person_id OR cr.person_id = p.person_id
-        WHERE (r.title ILIKE '%' || title || '%' OR r.title IS NULL)
-            AND (m.plot ILIKE '%' || plot || '%' OR m.plot IS NULL)
-            AND (ca."character" ILIKE '%' || "character" || '%' OR ca."character" IS NULL)
-            AND (p."name" ILIKE '%' || person || '%' OR p."name" IS NULL)
+        WHERE (r.title ILIKE '%' || p_title || '%' OR r.title IS NULL)
+            AND (m.plot ILIKE '%' || p_plot || '%' OR m.plot IS NULL)
+            AND (ca."character" ILIKE '%' || p_character || '%' OR ca."character" IS NULL)
+            AND (p."name" ILIKE '%' || p_person || '%' OR p."name" IS NULL)
     )
   SELECT DISTINCT imdb_id, title, media_type
   FROM search_result

--- a/src/D_functions_and_procedures.sql
+++ b/src/D_functions_and_procedures.sql
@@ -22,3 +22,43 @@ LANGUAGE 'plpgsql';
 
 --D2 TEST
 SELECT * FROM simple_search('apple',1);
+
+-- Structured string search
+
+CREATE OR REPLACE FUNCTION structured_string_search (
+  title VARCHAR(100), 
+  plot VARCHAR(100), 
+  "character" VARCHAR(100), 
+  person VARCHAR(100), 
+  user_id INTEGER
+)
+RETURNS TABLE (media_id INTEGER, title TEXT)
+AS $$
+BEGIN
+  -- SEARCH HISTORY
+  INSERT INTO search_history (user_id, type, query)
+  VALUES (user_id, 'structured_string_search', 
+          FORMAT('title: %s, plot: %s, character: %s, person: %s', title, plot, "character", person));
+
+  -- RESULT
+  RETURN QUERY
+  WITH
+    search_result AS (
+        SELECT DISTINCT m.media_id, m.imdb_id, m."type" AS media_type
+        FROM media AS m
+        JOIN "release" r USING (media_id)
+        LEFT JOIN crew_member cr ON m.media_id = cr.media_id
+        LEFT JOIN cast_member ca ON m.media_id = ca.media_id
+        LEFT JOIN person p ON ca.person_id = p.person_id OR cr.person_id = p.person_id
+        WHERE (r.title ILIKE '%' || title || '%' OR r.title IS NULL)
+            AND (m.plot ILIKE '%' || plot || '%' OR m.plot IS NULL)
+            AND (ca."character" ILIKE '%' || "character" || '%' OR ca."character" IS NULL)
+            AND (p."name" ILIKE '%' || person || '%' OR p."name" IS NULL)
+    )
+  SELECT DISTINCT imdb_id, title, media_type
+  FROM search_result
+  JOIN "release" USING (media_id)
+  WHERE "type" = 'original';
+END;
+$$
+LANGUAGE 'plpgsql';

--- a/src/D_functions_and_procedures.sql
+++ b/src/D_functions_and_procedures.sql
@@ -35,8 +35,8 @@ RETURNS TABLE (media_id INTEGER, title TEXT)
 AS $$
 BEGIN
   -- SEARCH HISTORY
-  INSERT INTO search_history (p_user_id, type, query)
-  VALUES (user_id, 'structured_string_search', 
+  INSERT INTO search_history (user_id, "type", query)
+  VALUES (p_user_id, 'structured_string_search', 
           FORMAT('title: %s, plot: %s, character: %s, person: %s', p_title, p_plot, p_character, p_person));
 
   -- RESULT
@@ -57,7 +57,7 @@ BEGIN
   SELECT DISTINCT imdb_id, title, media_type
   FROM search_result
   JOIN "release" USING (media_id)
-  WHERE "type" = 'original';
+  WHERE title_type = 'original';
 END;
 $$
 LANGUAGE 'plpgsql';

--- a/src/core_data_transform.sql
+++ b/src/core_data_transform.sql
@@ -345,7 +345,7 @@ FROM split_genres;
 -- Insert release for media
 WITH
     titleaka_with_id AS (
-        SELECT ta.title, t.startyear, m.media_id, ta.region, ta.types
+        SELECT t.primarytitle, ta.title, t.startyear, m.media_id, ta.region, ta.types
         FROM original.title_akas AS ta
         JOIN media AS m ON m.imdb_id = ta.titleid
         JOIN original.title_basics AS t ON t.tconst = ta.titleid
@@ -360,7 +360,11 @@ SELECT
         ELSE (SELECT country_id FROM country WHERE imdb_country_code = region) 
     END),
     (CASE
-	    WHEN region = '' THEN NULL
+	    WHEN types = '' THEN (CASE
+            WHEN originaltitle = title THEN 'original'
+            WHEN primarytitle = title THEN 'primary'
+            ELSE NULL
+        END)
         ELSE SPLIT_PART(types, U&'0002', 1)
     END)
 FROM titleaka_with_id;

--- a/src/core_data_transform.sql
+++ b/src/core_data_transform.sql
@@ -350,7 +350,7 @@ WITH
         JOIN media AS m ON m.imdb_id = ta.titleid
         JOIN original.title_basics AS t ON t.tconst = ta.titleid
     )
-INSERT INTO "release" (title, release_date, media_id, country_id, "type")
+INSERT INTO "release" (title, release_date, media_id, country_id, title_type)
 SELECT 
     title, 
     TO_DATE(startyear, 'YYYY'), 
@@ -407,11 +407,12 @@ BEGIN
         insert_count := insert_count + 1;
 
         -- Create title for season ('{series_title} - Season {season_number}')
-        INSERT INTO "release" (title, release_date, media_id)
+        INSERT INTO "release" (title, release_date, media_id, title_type)
         VALUES (
             FORMAT('%s - Season %s', current_season.show_title, current_season.season_number), 
             current_season.start_date, 
-            new_season_id);
+            new_season_id,
+            'primary');
 
         -- Increment the counter
         insert_count := insert_count + 1;

--- a/src/core_data_transform.sql
+++ b/src/core_data_transform.sql
@@ -345,7 +345,7 @@ FROM split_genres;
 -- Insert release for media
 WITH
     titleaka_with_id AS (
-        SELECT t.primarytitle, ta.title, t.startyear, m.media_id, ta.region, ta.types
+        SELECT t.originaltitle, t.primarytitle, ta.title, t.startyear, m.media_id, ta.region, ta.types
         FROM original.title_akas AS ta
         JOIN media AS m ON m.imdb_id = ta.titleid
         JOIN original.title_basics AS t ON t.tconst = ta.titleid


### PR DESCRIPTION
The PR implements the structured_string_search that returns titles for D.4

- Added: structured_string_search function
- Added: if empty release type is and title matches primary or original title set type as primary or original
- Changed: renamed release `type` to `title_type` for clarity

closing #15 