### PR TITLE
feat: D8 added - List Actors by Popularity - List Co-Actors by Popula…

### DIFF
--- a/src/D_functions_and_procedures.sql
+++ b/src/D_functions_and_procedures.sql
@@ -146,3 +146,39 @@ BEGIN
     PERFORM rate(john_id, 'tt1375666', 9.0); 
     PERFORM rate(jane_id, 'tt1375666', 7.0); 
 END $$;
+
+-- D8 List Actors by Popularity
+CREATE OR REPLACE FUNCTION list_actors_by_popularity(p_media_id INT)
+RETURNS TABLE (actor_id INT, actor_name TEXT, actor_rating DECIMAL(3, 2)) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT p.person_id, p."name", p.name_rating
+    FROM person p
+    INNER JOIN cast_member cm ON p.person_id = cm.person_id
+    WHERE cm.media_id = p_media_id
+    ORDER BY p.name_rating DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- D8 Test List Actors by Popularity
+-- Test with a sample media ID
+SELECT * FROM list_actors_by_popularity(1);
+
+-- D8 List Co-Actors by Popularity for a Given Actor
+CREATE OR REPLACE FUNCTION list_co_actors_by_popularity(p_actor_id INT)
+RETURNS TABLE (co_actor_id INT, co_actor_name TEXT, co_actor_rating DECIMAL(3, 2)) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT p2.person_id, p2."name", p2.name_rating
+    FROM cast_member cm1
+    INNER JOIN cast_member cm2 ON cm1.media_id = cm2.media_id
+    INNER JOIN person p2 ON cm2.person_id = p2.person_id
+    WHERE cm1.person_id = p_actor_id
+      AND cm2.person_id != p_actor_id
+    ORDER BY p2.name_rating DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- D8 Test List Co-Actors by Popularity
+-- Test with a sample actor ID
+SELECT * FROM list_co_actors_by_popularity(1);

--- a/src/D_functions_and_procedures.sql
+++ b/src/D_functions_and_procedures.sql
@@ -152,33 +152,34 @@ CREATE OR REPLACE FUNCTION list_actors_by_popularity(p_media_id INT)
 RETURNS TABLE (actor_id INT, actor_name TEXT, actor_rating DECIMAL(3, 2)) AS $$
 BEGIN
     RETURN QUERY
-    SELECT p.person_id, p."name", p.name_rating
+    SELECT p.person_id, 
+           p."name"::TEXT,
+           p.name_rating
     FROM person p
     INNER JOIN cast_member cm ON p.person_id = cm.person_id
     WHERE cm.media_id = p_media_id
     ORDER BY p.name_rating DESC;
 END;
 $$ LANGUAGE plpgsql;
-
--- D8 Test List Actors by Popularity
 -- Test with a sample media ID
-SELECT * FROM list_actors_by_popularity(1);
+SELECT * FROM list_actors_by_popularity(36);
 
 -- D8 List Co-Actors by Popularity for a Given Actor
 CREATE OR REPLACE FUNCTION list_co_actors_by_popularity(p_actor_id INT)
-RETURNS TABLE (co_actor_id INT, co_actor_name TEXT, co_actor_rating DECIMAL(3, 2)) AS $$
+RETURNS TABLE (co_actor_id INT, co_actor_name TEXT, co_actor_rating DECIMAL(6, 2)) AS $$
 BEGIN
     RETURN QUERY
-    SELECT DISTINCT p2.person_id, p2."name", p2.name_rating
+    SELECT DISTINCT p2.person_id, 
+                    p2."name"::TEXT,
+                    p2.name_rating
     FROM cast_member cm1
-    INNER JOIN cast_member cm2 ON cm1.media_id = cm2.media_id
+    INNER JOIN cast_member cm2 ON cm1.media_id = cm2.media_id  
     INNER JOIN person p2 ON cm2.person_id = p2.person_id
-    WHERE cm1.person_id = p_actor_id
+    WHERE cm1.person_id = p_actor_id 
       AND cm2.person_id != p_actor_id
+      AND p2.name_rating IS NOT NULL
     ORDER BY p2.name_rating DESC;
 END;
 $$ LANGUAGE plpgsql;
-
--- D8 Test List Co-Actors by Popularity
 -- Test with a sample actor ID
-SELECT * FROM list_co_actors_by_popularity(1);
+SELECT * FROM list_co_actors_by_popularity(64);


### PR DESCRIPTION
### **_DISCLAIMER: I just wanted to try the co-pilot auto generated PR comment functionality._**

This pull request introduces new functions to list actors and co-actors by popularity in the `src/D_functions_and_procedures.sql` file. These changes enhance the database's querying capabilities by allowing users to retrieve actors and their co-actors sorted by their ratings.

New functions for querying actors and co-actors by popularity:

* Added the `list_actors_by_popularity` function to return a table of actors associated with a specific media ID, ordered by their rating. (`src/D_functions_and_procedures.sql`, [src/D_functions_and_procedures.sqlR149-R184](diffhunk://#diff-8abe96fe7cebe376e1aa8eedbd13a3103a536c0f30259841afeb2c1e60eb419bR149-R184))
* Added the `list_co_actors_by_popularity` function to return a table of co-actors associated with a specific actor ID, ordered by their rating. (`src/D_functions_and_procedures.sql`, [src/D_functions_and_procedures.sqlR149-R184](diffhunk://#diff-8abe96fe7cebe376e1aa8eedbd13a3103a536c0f30259841afeb2c1e60eb419bR149-R184))

Test queries for new functions:

* Included a test query for the `list_actors_by_popularity` function using a sample media ID. (`src/D_functions_and_procedures.sql`, [src/D_functions_and_procedures.sqlR149-R184](diffhunk://#diff-8abe96fe7cebe376e1aa8eedbd13a3103a536c0f30259841afeb2c1e60eb419bR149-R184))
* Included a test query for the `list_co_actors_by_popularity` function using a sample actor ID. (`src/D_functions_and_procedures.sql`, [src/D_functions_and_procedures.sqlR149-R184](diffhunk://#diff-8abe96fe7cebe376e1aa8eedbd13a3103a536c0f30259841afeb2c1e60eb419bR149-R184))

- [x] #33 
- [x] #32 